### PR TITLE
Added return to oauth config

### DIFF
--- a/Authentication.md
+++ b/Authentication.md
@@ -53,6 +53,8 @@ Once you have the package you can configure the provider.
     $provider->setClientResolver(function ($id) {
         // Logic to return a client by their ID.
     });
+    
+    return $provider;
 }
 ```
 


### PR DESCRIPTION
OAuth configuration example was missing a return statement causing authentication issues.
