### PR TITLE
Fixed typo

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -15,7 +15,7 @@ Your vendor name is typically a short name of your application, all lowercase.
 You can configure this in your `.env` file.
 
 ```
-API_PREFIX=app
+API_VENDOR=app
 ```
 
 #### Prefixes and Subdomains


### PR DESCRIPTION
I believe this was wrong in documentation.

From:
 ```
API_PREFIX=app
 ```
To: 
```
API_VENDOR=app
 ```